### PR TITLE
chore: (DSO-2411) enable oidc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 - [Overview](#overview)
 - [Usage](#usage)
-  - [Example usage](#example-usage)
+  - [OIDC authentication (recommended)](#oidc-authentication-recommended)
+  - [Static credentials](#static-credentials)
+- [Inputs](#inputs)
 
 ## Overview
 
@@ -17,53 +19,70 @@ It provides options to configure Werf, AWS regions, run modes, and secrets for s
 
 See [action.yml](action.yml).
 
-``` yaml
-- uses: actions/werf-deployment-action@v0.0.2
-  with:
-    # Target environment to pass to tasks and Werf commands
-    environment: 'stage'
+### OIDC authentication (recommended)
 
-    # The Taskfile tasks (command separated) to run
-    # Puts the environment input as a CLI_ARG with '-- <env>'
-    # Tasks are run previous to Werf commands
-    tasks: >-
-      ecr-login,
-      kubeconfig
-
-    # The Werf commands to run without werf and --env
-    # Werf commands are run after tasks
-    commands: >-
-      render --repo <my-repo>,
-      plan --repo <my-repo>,
-      converge --repo <my-repo> --values .helm/values-<env>.yaml
-
-    # Specifies the AWS region name for configuration
-    aws_region: 'us-east-1'
-
-    # Optional. AWS service account access key
-    aws_access_key_id: '<key>'
-
-    # Optional. Ansible vault password to decrypt secrets
-    werf_secret_key: '<secret>'
-
-    # Optional. AWS service account secret access key
-    aws_secret_access_key: '<secret>'
-```
-
-### Example usage
+Use `role_arn` to have the action assume an IAM role via OIDC. No long-lived credentials are
+required. The calling workflow must grant `id-token: write` permission.
 
 ```yaml
-- uses: gbh-tech/werf-deployment-action@v0.0.2
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: gbh-tech/werf-deployment-action@v0.0.5
+        with:
+          environment: 'stage'
+          aws_region: 'us-east-1'
+          role_arn: '${{ vars.AWS_ROLE_ARN }}'
+          werf_secret_key: '${{ secrets.WERF_SECRET_KEY }}'
+          tasks: >-
+            ecr-login,
+            kubeconfig
+          commands: >-
+            render --repo 'id.aws.ecr/repo/myapp' --values '.helm/values-stage.yaml',
+            converge --repo 'id.aws.ecr/repo/myapp' --values '.helm/values-stage.yaml'
+```
+
+### Static credentials
+
+Use `aws_access_key_id` and `aws_secret_access_key` when OIDC is not available. If the credentials
+are temporary (STS-issued), also pass `aws_session_token`.
+
+```yaml
+- uses: gbh-tech/werf-deployment-action@v0.0.5
   with:
     environment: 'stage'
     aws_region: 'us-east-1'
     werf_secret_key: '${{ secrets.WERF_SECRET_KEY }}'
     aws_access_key_id: '${{ vars.AWS_ACCESS_KEY_ID }}'
     aws_secret_access_key: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
+    # aws_session_token: '${{ env.AWS_SESSION_TOKEN }}'  # required for temporary STS credentials
     tasks: >-
       ecr-login,
       kubeconfig
     commands: >-
       render --repo 'id.aws.ecr/repo/myapp' --values '.helm/values-stage.yaml',
-      converge --repo 'id.aws.ecr/repo/myapp', --values '.helm/values-stage.yaml'
+      converge --repo 'id.aws.ecr/repo/myapp' --values '.helm/values-stage.yaml'
 ```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `environment` | yes | — | Target environment passed to tasks and Werf commands |
+| `aws_region` | yes | — | AWS region |
+| `role_arn` | no | `''` | IAM role ARN to assume via OIDC. When set, OIDC auth is used and static key inputs are ignored. Requires `permissions: id-token: write` in the calling workflow. |
+| `aws_access_key_id` | no | `''` | AWS access key ID. Used only when `role_arn` is not set. |
+| `aws_secret_access_key` | no | `''` | AWS secret access key. Used only when `role_arn` is not set. |
+| `aws_session_token` | no | `''` | AWS session token for temporary STS credentials. Used only when `role_arn` is not set. |
+| `werf_secret_key` | no | `''` | Werf secret key written to `.werf_secret_key` |
+| `tasks` | no | — | Comma-separated Taskfile tasks to run before Werf commands. Each task receives `-- <environment>` as a CLI arg. |
+| `commands` | no | — | Comma-separated Werf commands to run (without the `werf` prefix and `--env` flag). |
+| `kubectl_version` | no | `v1.34.0` | kubectl version to install |
+| `task_version` | no | `3.43.2` | Task version to install |
+| `werf_version` | no | `v2.53.0` | Werf version to install |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: gbh-tech/werf-deployment-action@v0.0.5
         with:

--- a/action.yml
+++ b/action.yml
@@ -12,12 +12,18 @@ inputs:
   aws_region:
     description: 'AWS Region'
     required: true
+  role_arn:
+    description: 'IAM role ARN to assume via OIDC. When set, OIDC authentication is used and static key inputs are ignored. Requires the calling workflow to declare permissions: id-token: write.'
+    default: ''
   aws_access_key_id:
-    description: 'AWS Access Key from Service Account'
-    required: true
+    description: 'AWS access key ID. Used only when role_arn is not set.'
+    default: ''
   aws_secret_access_key:
-    description: 'AWS service account secret access key'
-    required: true
+    description: 'AWS secret access key. Used only when role_arn is not set.'
+    default: ''
+  aws_session_token:
+    description: 'AWS session token for temporary STS credentials. Used only when role_arn is not set.'
+    default: ''
   environment:
     description: 'Target environment'
     required: true
@@ -38,12 +44,21 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Configure AWS service account credentials
-      uses: aws-actions/configure-aws-credentials@v4
+    - name: Configure AWS credentials (OIDC)
+      if: ${{ inputs.role_arn != '' }}
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        aws-region: ${{ inputs.aws_region }}
+        role-to-assume: ${{ inputs.role_arn }}
+
+    - name: Configure AWS credentials (static keys)
+      if: ${{ inputs.role_arn == '' }}
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: ${{ inputs.aws_region }}
         aws-access-key-id: ${{ inputs.aws_access_key_id }}
         aws-secret-access-key: ${{ inputs.aws_secret_access_key }}
+        aws-session-token: ${{ inputs.aws_session_token }}
 
     - name: Add Werf secret key
       shell: bash -leo pipefail {0}


### PR DESCRIPTION
## Summary
This update enhances werf-deployment-action with flexible AWS authentication.

- Introduces a role_arn input for IAM role assumption via OIDC. 
- Adds aws_session_token support to ensure proper authentication when temporary STS credentials are used by upstream OIDC steps.
- ws_access_key_id and aws_secret_access_key are now optional
- Bump aws-actions/configure-aws-credentials to v6
